### PR TITLE
Show synced documents count when running `node import-npm.js`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea


### PR DESCRIPTION
Thank you for creating this demo. It's helped me to learn about Node.js profiling with clinic.js.

Added a small feature to show synced documents count when importing sample data. Feel free to close this PR if it's an unnecessary addition. :+1: 

![bubbleprof](https://user-images.githubusercontent.com/12813750/85195864-8d8f5780-b2f3-11ea-9725-fe043ce0b859.gif)
